### PR TITLE
Seg padding

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -61,7 +61,9 @@ parser.add_argument('-p', '--segment-pad', type=float, default=0.1,
                     help='minimum padding (one-sided) for output segments '
                          'when using --output-format '
                          '[segments|integer-segments]')
-
+parser.add_argument('-s', '--segment-end-pad', type=float, default=1.0,
+                    help='amount of time to remove from the end of each '
+                         'analysis segment')
 args = parser.parse_args()
 
 # get segments
@@ -84,7 +86,7 @@ for dcuid in args.dcuid:
     for seg in cachesegs:
         c = cache.sieve(segment=seg)
         data = TimeSeries.read(c, channel, nproc=args.nproc,
-                               start=seg[0], end=seg[1])
+                               start=seg[0], end=seg[1]-args.segment_end_pad)
         times = overflow.find_overflows(data)
 
         if args.deep and times.size > 0:

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -85,6 +85,8 @@ for dcuid in args.dcuid:
     channel = overflow.ligo_accum_overflow_channel(dcuid, args.ifo)
     for seg in cachesegs:
         c = cache.sieve(segment=seg)
+        if (seg[1]-args.segment_end_pad) < seg[0]:
+            continue
         data = TimeSeries.read(c, channel, nproc=args.nproc,
                                start=seg[0], end=seg[1]-args.segment_end_pad)
         times = overflow.find_overflows(data)


### PR DESCRIPTION
Tested the output of the code with "-s 0" as command line argument and results were unchanged. Also tested leaving out the -s argument at all and results were unchanged. Just to make sure, ran with a large padding that removed one trigger but not the one just before it and it worked well.

Added an if statement that says, "If my segment is shorter than my padding window, go to the next segment because data query would fail"