### PR TITLE
Added --colormap option to wdq tool

### DIFF
--- a/bin/wdq
+++ b/bin/wdq
@@ -49,6 +49,11 @@ parser.add_argument('-w', '--wpipeline', default=omega.WPIPELINE,
                     required=omega.WPIPELINE is None,
                     help='path to wpipeline binary, default: %(default)s')
 
+oargs = parser.add_argument_group('Omega options')
+oargs.add_argument('-c', '--colormap', default='parula',
+                  help='name of colormap to use (only supported for '
+                       'omega > r3449)')
+
 args = parser.parse_args()
 
 print("----------------------------------------------\n"
@@ -120,4 +125,4 @@ print("Cachefile generated as %s" % cachefile)
 
 # run scan
 omega.run(gps, args.config_file, cachefile, outdir=outdir,
-          wpipeline=args.wpipeline, verbose=True)
+          wpipeline=args.wpipeline, colormap=args.colormap, verbose=True)

--- a/gwdetchar/omega/scan.py
+++ b/gwdetchar/omega/scan.py
@@ -30,6 +30,21 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 OMEGA_LOCATION = os.getenv('OMEGA_LOCATION', None)
 WPIPELINE = OMEGA_LOCATION and os.path.join(OMEGA_LOCATION, 'bin', 'wpipeline')
 
+# -- utilities ----------------------------------------------------------------
+
+def get_omega_version(executable='/home/omega/opt/omega/bin/wpipeline'):
+    """Determine the omega version from the executable
+
+    >>> get_omega_version()
+    'r3449'
+    """
+    cmd = [executable, 'version']
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode:
+        raise subprocess.CalledProcessError(p.returncode, ' '.join(cmd))
+    return out.split('\n')[0].split(' ')[-1]
+
 
 # -- scan configuration parsing -----------------------------------------------
 

--- a/gwdetchar/omega/scan.py
+++ b/gwdetchar/omega/scan.py
@@ -143,7 +143,7 @@ def omega_param(val):
 # -- scan processing ----------------------------------------------------------
 
 def run(gpstime, config, cachefile, outdir='.', report=True,
-        wpipeline=WPIPELINE, verbose=False):
+        wpipeline=WPIPELINE, colormap='parula', verbose=False):
     """Run a wpipeline scan at the given GPS time
 
     Parameters
@@ -171,10 +171,20 @@ def run(gpstime, config, cachefile, outdir='.', report=True,
     if wpipeline is None:
         raise RuntimeError("Unable to determine wpipeline path automatically, "
                            "please give explicitly")
-    cmd = [wpipeline, 'scan', '--configuration', config,
-           '--framecache', cachefile, '--outdir', outdir, str(gpstime)]
+    # create command
+    cmd = [wpipeline, 'scan', str(gpstime), '--configuration', config,
+           '--framecache', cachefile, '--outdir', outdir]
     if report:
         cmd.append('--report')
+    # if omega is new enough, add the --colormap option
+    try:
+        version = get_omega_version(wpipeline)
+    except subprocess.CalledProcessError:
+        pass
+    else:
+        if version >= 'r3449':
+            cmd.extend(('--colormap', colormap))
+    # RUN
     if verbose:
         print("Running omega scan as\n\n%s\n" % ' '.join(cmd))
     proc = subprocess.Popen(cmd, stdout=verbose and subprocess.PIPE or None)


### PR DESCRIPTION
This PR adds a `--colormap` option to the `wdq` command-line omega scan utility, which gets passed down to `wpipeline` if using `r3449` or greater.