### PR TITLE
Scaling data with RMS to correct for outliers within the data

### DIFF
--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -132,9 +132,12 @@ corr3 = spearmanr(rangets.value, darmblrms.value)[0]**2
 # create scaled versions of data to compare to each other
 print("-- Creating scaled data")
 rangescaled = rangets.detrend()
-rangemax = rangescaled.value.max()
+rangerms = numpy.sqrt(sum(rangescaled**2.0)/len(rangescaled))
 darmscaled = darmblrms.detrend()
-darmscaled *= (-rangemax / darmscaled.value.max())
+darmrms = numpy.sqrt(sum(darmscaled**2.0)/len(darmscaled))
+
+#create scaled darm using the rms(range) and the rms(darm)
+darmscaled *= (-rangerms / darmrms)
 
 # get aux data
 print("-- Loading auxiliary channel data")
@@ -204,7 +207,8 @@ def process_channel(input_):
 
         # plot auto-scaled verions
         tsscaled = ts.detrend()
-        tsscaled *= rangemax / tsscaled.value.max()
+        tsrms = numpy.sqrt(sum(tsscaled**2.0)/len(tsscaled))
+        tsscaled *= (rangerms / tsrms)
         if corr1 > 0:
             tsscaled *= -1
         plot = TimeSeriesPlot(darmscaled, rangescaled, tsscaled,


### PR DESCRIPTION
The scaling of data using the max values of the data failed to work when there were any big deviations in any of the channels. Here is an example of the output display that the original version of the code creates when there is an outlier in the data.
![image-1](https://cloud.githubusercontent.com/assets/20211899/17191641/a9c1fa40-53ff-11e6-8985-7155b598305e.jpg)

Isa created a short Python notebook where she uses arbitrary functions as two different sets of data to show how  the scaling of data using RMS works much better when having a big deviation in the data. (https://files.slack.com/files-pri/T04CYEMQN-F1V0EU49X/detrendwithrms.pdf)

After incorporating the RMS scaling to the code (by making local changes to the code) I ran the code for the same time that the code showed to be faulty up above in the picture and these are the new results. (https://ldas-jobs.ligo-la.caltech.edu/~katerin.aleman/detchar/03/L1-slow-correlation-1133906417-14443/)