### PR TITLE
Changes to allow reading second trend aux channels in slow correlations

### DIFF
--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -1,4 +1,4 @@
-#!/home/jrsmith/opt/gwpysoft/bin/python
+#!/usr/bin/env python
 # coding=utf-8
 # Copyright (C) LIGO Scientific Collaboration (2015-)
 #

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/jrsmith/opt/gwpysoft/bin/python
 # coding=utf-8
 # Copyright (C) LIGO Scientific Collaboration (2015-)
 #
@@ -124,10 +124,14 @@ else:
     darmblrms = darmts.notch(60).crop(dstart, dend).rms(stride)
     darmblrms.name = '%s RMS' % primary
 
-# calculate the r^2 value between the DARM BLRMS and the Range timeseries
-corr0 = numpy.corrcoef(rangets.value, darmblrms.value)[0, 1]**2
-# calculate the ρ^2 value between the DARM BLRMS and the Range timeseries
-corr3 = spearmanr(rangets.value, darmblrms.value)[0]**2
+if args.trend_type == 'minute':
+    # calculate the r^2 value between the DARM BLRMS and the Range timeseries
+    corr0 = numpy.corrcoef(rangets.value, darmblrms.value)[0, 1]**2
+    # calculate the ρ^2 value between the DARM BLRMS and the Range timeseries
+    corr3 = spearmanr(rangets.value, darmblrms.value)[0]**2
+else:
+    corr0 = 0
+    corr3 = 0
 
 # create scaled versions of data to compare to each other
 print("-- Creating scaled data")
@@ -137,7 +141,8 @@ darmscaled = darmblrms.detrend()
 darmrms = numpy.sqrt(sum(darmscaled**2.0)/len(darmscaled))
 
 #create scaled darm using the rms(range) and the rms(darm)
-darmscaled *= (-rangerms / darmrms)
+if args.trend_type == 'minute':
+    darmscaled *= (-rangerms / darmrms)
 
 # get aux data
 print("-- Loading auxiliary channel data")
@@ -208,9 +213,14 @@ def process_channel(input_):
         # plot auto-scaled verions
         tsscaled = ts.detrend()
         tsrms = numpy.sqrt(sum(tsscaled**2.0)/len(tsscaled))
-        tsscaled *= (rangerms / tsrms)
-        if corr1 > 0:
-            tsscaled *= -1
+        if args.trend_type == 'minute':
+            tsscaled *= (rangerms / tsrms)
+            if corr1 > 0:
+                tsscaled *= -1
+        else:
+            tsscaled *= (darmrms / tsrms)
+            if corr1 < 0:
+                tsscaled *= -1
         plot = TimeSeriesPlot(darmscaled, rangescaled, tsscaled,
                               figsize=[12, 6])
         plot.subplots_adjust(*p2)


### PR DESCRIPTION
I added a few if statements to make the code not break when reading second trend data for the auxiliary channels. In particular, it only calculates correlation with range for minute trends, and only scales and gets the sign of the aux channel from range when using minute trends (for second trends it gets scaling and sign from the BLRMS data). 

To show that this works I made a page for minute trends and one for second trends. The latter was previously not possible. 

- minute trends page: https://ldas-jobs.ligo-la.caltech.edu/~jrsmith/detchar/postO1/breathing-1156556417-600/
- second trends page: https://ldas-jobs.ligo-la.caltech.edu/~jrsmith/detchar/postO1/118Hz-1156734017-600/

The command line arguments are:
```
gwdetchar-slow-correlation -i L1 -b 10 20 -T minute -f chans.txt 1156556417 1156557017
gwdetchar-slow-correlation -i L1 -b 10 20 -T second -f chans.txt 1156556417 1156557017
```