### PR TITLE
Sort channels by max over all correlations, fix plot y-axis label

### DIFF
--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -130,10 +130,7 @@ if args.trend_type == 'minute':
     # calculate the ρ^2 value between the DARM BLRMS and the Range timeseries
     corr3 = spearmanr(rangets.value, darmblrms.value)[0]**2
 else:
-<<<<<<< HEAD
     # for second trends, set correlation to 0 since sample rates differ
-=======
->>>>>>> 863f62c084d0feb8a1f10d7956e1b13a1494e595
     corr0 = 0
     corr3 = 0
 

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/jrsmith/opt/gwpysoft/bin/python
 # coding=utf-8
 # Copyright (C) LIGO Scientific Collaboration (2015-)
 #

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -1,4 +1,4 @@
-#!/home/jrsmith/opt/gwpysoft/bin/python
+#!/usr/bin/env python
 # coding=utf-8
 # Copyright (C) LIGO Scientific Collaboration (2015-)
 #

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -130,6 +130,10 @@ if args.trend_type == 'minute':
     # calculate the ρ^2 value between the DARM BLRMS and the Range timeseries
     corr3 = spearmanr(rangets.value, darmblrms.value)[0]**2
 else:
+<<<<<<< HEAD
+    # for second trends, set correlation to 0 since sample rates differ
+=======
+>>>>>>> 863f62c084d0feb8a1f10d7956e1b13a1494e595
     corr0 = 0
     corr3 = 0
 
@@ -227,7 +231,7 @@ def process_channel(input_):
         ax = plot.gca()
         ax.set_xlim(start, end)
         ax.set_epoch(start)
-        ax.set_ylabel('Scaled amplitude [arbitrary units')
+        ax.set_ylabel('Scaled amplitude [arbitrary units]')
         ax.legend(loc='best')
         plot2 = '%s_COMPARISON-%s.png' % (channelstub, gpsstub)
         try:
@@ -248,7 +252,7 @@ def process_channel(input_):
 
 pool = multiprocessing.Pool(nprocplot)
 results = pool.map(process_channel, auxdata.iteritems())
-results.sort(key=lambda x: (x[1] is not None and x[1] + x[2] or 0, x[0]),
+results.sort(key=lambda x: (x[1] is not None and max(x[1],x[2],x[5],x[6]) or 0, x[0]),
              reverse=True)
 rhos = numpy.asarray([x[1] for x in results if x is not None])
 


### PR DESCRIPTION
This PR does: 
1) Sorts the list of channels in the final webpage by the maximum of r_blrms, r_range, rho_blrms, rho_range, so if anything interesting happens, it will be at the top. 
2) Adds a "]" that was missing from a y-axis label. 
3) Adds a comment about why we don't calculate correlation when using second trends. 
Here's output using this code: https://ldas-jobs.ligo-la.caltech.edu/~jrsmith/detchar/postO1/test-maxSorting/ 
The command was 
`gwdetchar-slow-correlation -i L1 -b 114 124 -J 16 -j 16 -T minute -r L1:DMT-SNSW_EFFECTIVE_RANGE_MPC.mean -f pem.txt 1157274000 1157308200`