### PR TITLE
Spline outliers

### DIFF
--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -102,7 +102,6 @@ def remove_outliers(ts,N):
         print('-- Found %d outliers in %s, recursively removing' % (len(outliers),ts.name))
         while outliers.any():
             cache = outliers
-            print('Channel median is: %.2E' % ts.median())
             mask = numpy.ones(len(ts), dtype=bool)
             mask[outliers] = False
             spline = UnivariateSpline(ts[mask].times.value,ts[mask].value,s=0,k=3)

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -148,8 +148,6 @@ else:
     darmblrms = darmts.notch(60).crop(dstart, dend).rms(stride)
     darmblrms.name = '%s RMS' % primary
 
-print('BLRMS median is: %.2E' % darmblrms.median())
-
 if args.remove_outliers:
     print('-- Removing outliers above %f sigma' % args.remove_outliers)
     remove_outliers(darmblrms,args.remove_outliers)

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -26,6 +26,7 @@ import sys
 
 import numpy
 from scipy.stats import spearmanr
+from scipy.interpolate import UnivariateSpline
 
 from matplotlib import use
 use('agg')
@@ -96,14 +97,23 @@ nprocplot = args.nproc_plot or args.nproc
 
 def remove_outliers(ts,N):
     outliers = numpy.nonzero(abs(ts - numpy.mean(ts)) > N*numpy.std(ts))[0]
-    for idx in outliers:
-        if idx == 0:
-            ts.value[idx] = numpy.mean([ts.value[idx+1],ts.value[idx+2]])
-        elif idx == (len(ts)-1):
-            ts.value[idx] = numpy.mean([ts.value[idx-1],ts.value[idx-2]])
-        else:
-            ts.value[idx] = numpy.mean([ts.value[idx-1],ts.value[idx+1]])
-    return
+    c = 1
+    if outliers.any():
+        print('-- Found %d outliers in %s, recursively removing' % (len(outliers),ts.name))
+        while outliers.any():
+            cache = outliers
+            print('Channel median is: %.2E' % ts.median())
+            mask = numpy.ones(len(ts), dtype=bool)
+            mask[outliers] = False
+            spline = UnivariateSpline(ts[mask].times.value,ts[mask].value,s=0,k=3)
+            ts[outliers] = spline(ts[outliers].times.value)
+            outliers = numpy.nonzero(abs(ts - numpy.mean(ts)) > N*numpy.std(ts))[0]
+            print('Completed %d removal cycles' % c)
+            if numpy.array_equal(outliers,cache):
+                print('Outliers did not change, breaking recursion')
+                break
+            print('%d outliers remain' % len(outliers))
+            c += 1
 
 # load data
 print("-- Loading range data")
@@ -130,14 +140,19 @@ else:
     stride = 1
 if flower:
     darmblrms = (
-        darmts.highpass(flower/2.).notch(60).bandpass(flower, fupper).crop(
-            dstart, dend).rms(stride))
+        darmts.highpass(flower/2., fstop=flower/4., filtfilt=False, ftype='butter').notch(
+        60, filtfilt=False).bandpass(
+        flower, fupper, fstop=[flower/2., fupper*1.5], filtfilt=False, ftype='butter').crop(
+        dstart, dend).rms(stride))
     darmblrms.name = '%s %s-%s Hz BLRMS' % (primary, flower, fupper)
 else:
     darmblrms = darmts.notch(60).crop(dstart, dend).rms(stride)
     darmblrms.name = '%s RMS' % primary
 
+print('BLRMS median is: %.2E' % darmblrms.median())
+
 if args.remove_outliers:
+    print('-- Removing outliers above %f sigma' % args.remove_outliers)
     remove_outliers(darmblrms,args.remove_outliers)
     remove_outliers(rangets,args.remove_outliers)
 


### PR DESCRIPTION
This PR adds the ability to do recursive outlier removal, replacing each outlier with a spline interpolated data point, and adds static filter settings to the BLRMS calculation. 

Example calls
No removal:
```
gwdetchar-slow-correlation -i H1 -b 45 90 -J 20 -j 20 -T minute -f chans.txt 1165111217 1165190357
```
Results: https://ldas-jobs.ligo-wa.caltech.edu/~tjmassin/detchar/slow-correlations/recreate_old/no_removal/

3 sigma removal:
```
gwdetchar-slow-correlation --remove-outliers 3 -i H1 -b 45 90 -J 20 -j 20 -T minute -f chans.txt 1165111217 1165190357
```
Results: https://ldas-jobs.ligo-wa.caltech.edu/~tjmassin/detchar/slow-correlations/recreate_old/3sigma_recursive/

5 sigma removal:
```
gwdetchar-slow-correlation --remove-outliers 5 -i H1 -b 45 90 -J 20 -j 20 -T minute -f chans.txt 1165111217 1165190357
```
Results: https://ldas-jobs.ligo-wa.caltech.edu/~tjmassin/detchar/slow-correlations/recreate_old/5sigma_recursive/