### PR TITLE
Tells when code is done running

### DIFF
--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -425,3 +425,5 @@ write_param('Band-pass', '%s-%s' % (flower, fupper))
 page.div.close()  # container
 with open('index.html', 'w') as f:
     print(str(page), file=f)
+
+print ("--Process Completed")

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -426,4 +426,4 @@ page.div.close()  # container
 with open('index.html', 'w') as f:
     print(str(page), file=f)
 
-print ("--Process Completed")
+print ("-- Process Completed")


### PR DESCRIPTION
Added a `--Process Completed` message to print when the script is done running all the way through so we can tell whether or not it is still running.
Ex1. (Run to 100%)
`Identified 2 channels`
`Attempting to access data from frames...`
`Reading data from H1_M frames... Done`
`-- Processing channels`
`Completed [2/2] 100% (H1:PEM-EX_ADC_0_13_OUT16.rms)   `                 
`-- Process Completed `
Ex2. (Shows the script running only up to 88%, but in actuality is finished)
 `Completed [9864/11400]  86% (H1:PEM-VAULT_SEIS_1030X195Y_STS2_X_BLRMS_INPUT_GAIN `
`Completed [9865/11400]  86% (H1:PEM-VAULT_SEIS_1030X195Y_STS2_X_BLRMS_INPUT_GAIN`
`Completed [10074/11400]  88% (H1:PEM-MY_SEIS_VEA_FLOOR_Y_BLRMS_INPUT_EXCMON.mean`
`Completed [10083/11400]  88% (H1:PEM-MY_SEIS_VEA_FLOOR_Y_BLRMS_INPUT_INMON.n)  )`
`-- Process Completed`