### PR TITLE
Removed deprecated function StripTableName

### DIFF
--- a/bin/gwdetchar-mct
+++ b/bin/gwdetchar-mct
@@ -115,7 +115,7 @@ for seg in cachesegs:
     for thresh in args.threshold:
         times = find_crossings(data,thresh)
         gprint('Found %d crossings for threshold %d' % (len(times),thresh))
-        gprint('Rate of crossings: %d Hz' % (len(times)/abs(seg)))
+        gprint('Rate of crossings: %.2f Hz' % (float(len(times))/abs(seg)))
         if len(times) and (len(times)/abs(seg) < args.rate_thresh):
             tables[str(thresh)].extend(table_from_times(times))
 

--- a/gwdetchar/io/ligolw.py
+++ b/gwdetchar/io/ligolw.py
@@ -47,7 +47,7 @@ def new_table(tab, *args, **kwargs):
         a newly-created table with the relevant attributes and structure
     """
     if isinstance(tab, str):
-        tab = lsctables.TableByName[table.StripTableName(tab)]
+        tab = lsctables.TableByName[table.Table.TableName(tab)]
     return lsctables.New(tab, *args, **kwargs)
 
 


### PR DESCRIPTION
I was able to successfully run the `gwdetchar-mct` executable with this change in place.