### PR TITLE
Build LAL for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,22 @@ language: python
 
 addons:
   apt:
+    sources:
+      - sourceline: deb http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
+      - sourceline: deb-src http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
     packages:
       - gfortran  # scipy
       - libblas-dev  # scipy
       - liblapack-dev  # scipy
       - swig  # m2crypto
+      - pkg-config  # lal
+      - zlib1g-dev  # lal
+      - libgsl0-dev  # lal
+      - swig  # lal
+      - bc  # lal
+      - libfftw3-dev  # lal
 
 python:
   - '2.6'
@@ -14,28 +25,27 @@ python:
   - '3.5'
 
 env:
-  - PRE="--pre"
-  - PRE=""
+  global:
+    - LAL_VERSION="6.18.0"
+  matrix:
+    - PIP_FLAGS="--quiet --pre"
+    - PIP_FLAGS="--quiet"
 
 matrix:
   exclude:
-    - python: "2.6"
-      env: PRE="--pre"
+    - python: '2.6'
+      env: PIP_FLAGS="--quiet --pre"
   allow_failures:
-    - python: "2.6"
-      env: PRE=""
-    - python: "2.7"
-      env: PRE="--pre"
-    - python: "3.5"
-      env: PRE=""
-    - python: "3.5"
-      env: PRE="--pre"
+    - python: '2.6'
+    - python: '3.5'
+  fast_finish: true
 
 before_install:
   - pip install -q --upgrade pip
   # need to install astropy 1.1 specifically for py26
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
-  - pip install ${PRE} -r requirements.txt
+  - pip install ${PIP_FLAGS} -r requirements.txt
+  - .travis/build-lal.sh
   - pip install coveralls unittest2 pytest
 
 install:
@@ -53,3 +63,5 @@ after_success:
 cache:
   apt: true
   pip: true
+  directories:
+    - lal-${LAL_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,17 @@ addons:
       - sourceline: deb-src http://software.ligo.org/lscsoft/debian wheezy contrib
         key_url: http://software.ligo.org/keys/deb/lscsoft.key
     packages:
+      # lal dependencies
+      - pkg-config
+      - zlib1g-dev
+      - libgsl0-dev
+      - swig
+      - bc
+      - libfftw3-dev
+      # other dependencies
       - gfortran  # scipy
       - libblas-dev  # scipy
       - liblapack-dev  # scipy
-      - swig  # m2crypto
-      - pkg-config  # lal
-      - zlib1g-dev  # lal
-      - libgsl0-dev  # lal
-      - swig  # lal
-      - bc  # lal
-      - libfftw3-dev  # lal
 
 python:
   - '2.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
   - pip install ${PIP_FLAGS} -r requirements.txt
   - .travis/build-lal.sh
-  - pip install coveralls unittest2 pytest
+  - pip install ${PIP_FLAGS} coveralls unittest2 pytest
 
 install:
   - pip install .

--- a/.travis/build-lal.sh
+++ b/.travis/build-lal.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+set -x
+
+LAL_TAG="lal-${LAL_VERSION}"
+LAL_TARBALL="${LAL_TAG}.tar.xz"
+LAL_SOURCE="http://software.ligo.org/lscsoft/source/lalsuite"
+
+target=`python -c "import sys; print(sys.prefix)"`
+
+echo "----------------------------------------------------------------------"
+echo "Installing from ${LAL_TARBALL}"
+
+wget ${LAL_SOURCE}/${LAL_TARBALL} -O ${LAL_TARBALL} --quiet
+mkdir -p ${LAL_TAG}
+tar -xf ${LAL_TARBALL} --strip-components=1 -C ${LAL_TAG}
+cd ${LAL_TAG}
+./configure --enable-silent-rules --enable-swig-python --quiet --prefix=${target}
+make --silent
+make install --silent

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astropy
 m2crypto
 pykerberos
 python-cjson
-http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
-http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
+http://software.ligo.org/lscsoft/source/glue-1.54.1.tar.gz
+http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
 gwpy

--- a/setup.py
+++ b/setup.py
@@ -95,10 +95,10 @@ setup(name=DISTNAME,
       requires=requires,
       extras_require=extras_require,
       dependency_links=[
-          'http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz'
-              '#egg=glue-1.49.1',
-          'http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz'
-              '#egg=dqsegdb-1.2.2',
+          'http://software.ligo.org/lscsoft/source/glue-1.54.1.tar.gz'
+              '#egg=glue-1.54.1',
+          'http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz'
+              '#egg=dqsegdb-1.4.0',
           'https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz'
               '#egg=trigfind-0.3',
       ],

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,11 @@ setup_requires = [
     'pytest-runner',
 ]
 install_requires = [
-    'numpy>=1.5',
-    'matplotlib>=1.3.0',
-    'astropy>=1.0',
-    'gwpy>=0.1',
+    'numpy>=1.10',
+    'scipy>=1.16',
+    'matplotlib>=1.4.1',
+    'astropy>=1.2',
+    'gwpy>=0.3',
     'trigfind>=0.3',
 ]
 requires = [

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_requires = [
 ]
 install_requires = [
     'numpy>=1.10',
-    'scipy>=1.16',
+    'scipy>=0.16',
     'matplotlib>=1.4.1',
     'astropy>=1.2',
     'gwpy>=0.3',


### PR DESCRIPTION
This PR adds a build of LAL for travis CI build and test. `lal` is required for `glue`.