### PR TITLE
Optimised gwdetchar-software-saturations

### DIFF
--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -424,7 +424,7 @@ if len(bad):
 outfile = ('%s-SOFTWARE_SATURATIONS-%d-%d.xml.gz'
            % (ifo, int(args.gpsstart),
               int(args.gpsend) - int(args.gpsstart)))
-saturations.write(outfile)
+saturations.write(outfile, overwrite=True)
 print("Saturation segments written to \n%s" % outfile)
 
 if args.html:

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -265,8 +265,7 @@ def is_saturated(channel, cache, start=None, end=None,
 #
 # -----------------------------------------------------------------------------
 
-# -----------------------------------------------------------------------------
-# parse command line
+# -- parse command line -------------------------------------------------------
 
 parser = cli.create_parser(description=__doc__)
 cli.add_gps_start_stop_arguments(parser)
@@ -395,8 +394,7 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
                       % (c, i*ngroup + j + 1, nchans), end='\r')
             sys.stdout.flush()
 
-# -----------------------------------------------------------------------------
-# print results and exit
+# -- print results and exit ---------------------------------------------------
 
 print("\n----------------------------------------------------------------"
       "-----")

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -27,7 +27,7 @@ import os
 import re
 import subprocess
 import sys
-from multiprocessing import cpu_count
+from multiprocessing import (Pool, cpu_count)
 from StringIO import StringIO
 
 from matplotlib import use
@@ -157,6 +157,12 @@ def find_limit_channels(channels, skip=None):
     return limens, swstats
 
 
+def _find_saturations(data):
+    out = find_saturations(data[0], data[1], precision=.99, segments=True)
+    out.name = out.name[:-7]
+    return out
+
+
 def is_saturated(channel, cache, start=None, end=None,
                  indicator='LIMEN', nproc=DEFAULT_NPROC, segments=True):
     """Check whether a channel has saturated its software limit
@@ -224,28 +230,22 @@ def is_saturated(channel, cache, start=None, end=None,
                  s in ('LIMIT', 'OUTPUT')]
     data = TimeSeriesDict.read(cache, datachans, start=start, end=end,
                                nproc=nproc, **iokwargs)
-    # loop over channels and return the following:
-    #     no limit      -   None
-    #     no saturation -   False
-    #     saturation    -   True
-    out = []
-    for c in channels:
-        if c not in activechans:
-            out.append(None)
-            continue
-        if segments:
-            out.append(find_saturations(data['%s_OUTPUT' % c],
-                                        data['%s_LIMIT' % c], precision=.99,
-                                        segments=True))
-            out[-1].name = out[-1].name[:-7]
-        else:
-            out.append(find_saturations(data['%s_OUTPUT' % c],
-                                        data['%s_LIMIT' % c],
-                                        precision=.99).any())
-    if isinstance(channel, (list, tuple)):
-        return out
+
+    # find saturations of the limit for each channel
+    dataiter = ((data['%s_OUTPUT' % c], data['%s_LIMIT' % c])
+                for c in activechans)
+    if nproc > 1:
+        pool = Pool(processes=nproc)
+        saturations = list(pool.map(_find_saturations, dataiter))
+        pool.close()
     else:
-        return out[0]
+        saturations = list(map(_find_saturations, dataiter))
+
+    # return many or one (based on input)
+    if isinstance(channel, (list, tuple)):
+        return saturations
+    else:
+        return saturations[0]
 
 
 # -----------------------------------------------------------------------------
@@ -360,15 +360,18 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
             saturated = is_saturated(cset, cache2, seg[0], seg[1],
                                      indicator=suffix, nproc=args.nproc,
                                      segments=True)
-            for j, (c, sat) in enumerate(zip(cset, saturated)):
-                if sat is not None:
-                    try:
-                        saturations[c] += sat
-                    except KeyError:
-                        saturations[c] = sat
+            for new in saturated:
+                try:
+                    saturations[new.name] += new
+                except KeyError:
+                    saturations[new.name] = new
         for j, c in enumerate(cset):
-            if c in saturations:
+            try:
                 sat = saturations[c]
+            except KeyError:
+                print('%40s:      SKIP      [%d/%d]'
+                      % (c, i*ngroup + j + 1, nchans), end='\r')
+            else:
                 if abs(sat.active):
                     print('%40s: ---- FAIL ---- [%d/%d]'
                           % (c, i*ngroup + j + 1, nchans))
@@ -378,9 +381,6 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
                 else:
                     print('%40s:      PASS      [%d/%d]'
                           % (c, i*ngroup + j + 1, nchans))
-            else:
-                print('%40s:      SKIP      [%d/%d]'
-                      % (c, i*ngroup + j + 1, nchans), end='\r')
             sys.stdout.flush()
 
 # -- print results and exit ---------------------------------------------------

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -45,6 +45,13 @@ from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import find_frames
 from gwdetchar.saturation import find_saturations
 
+try:
+    from LDAStools import frameCPP
+except ImportError:
+    HAS_FRAMECPP = False
+else:
+    HAS_FRAMECPP = True
+
 __author__ = 'Dan Hoak <daniel.hoak@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -217,8 +224,12 @@ def is_saturated(channel, cache, start=None, end=None,
             channels[i] = c[:-6]
     # check limit if set
     indicators = ['%s_%s' % (c, indicator) for c in channels]
+    if HAS_FRAMECPP:
+        iokwargs = {'type': 'adc', 'format': 'gwf.framecpp'}
+    else:
+        iokwargs = {'format': 'gwf'}
     data = TimeSeriesDict.read(
-        cache[0].path, indicators, start=start, end=start+1)
+        cache[0].path, indicators, start=start, end=start+1, **iokwargs)
     if indicator.upper() == 'LIMEN':
         active = dict((c, data[indicators[i]].value[0]) for
                       i, c in enumerate(channels))
@@ -234,7 +245,7 @@ def is_saturated(channel, cache, start=None, end=None,
     datachans = ['%s_%s' % (c, s) for c in activechans for
                  s in ('LIMIT', 'OUTPUT')]
     data = TimeSeriesDict.read(cache, datachans, start=start, end=end,
-                               nproc=nproc)
+                               nproc=nproc, **iokwargs)
     # loop over channels and return the following:
     #     no limit      -   None
     #     no saturation -   False

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -35,6 +35,7 @@ use('agg')
 
 from glue import markup
 
+from gwpy.io.gwf import get_channel_names
 from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 from gwpy.time import to_gps
@@ -119,29 +120,6 @@ def plot_saturations(flag, span, facecolor='red', edgecolor='darkred',
     plot.set_xlim(*span)
     plot.set_epoch(span[0])
     return plot
-
-
-def get_adc_channels(framefile):
-    """Return the names of all ADC channels stored in the framefile
-    """
-    # try just using FrChannels in a subprocess, it's faster
-    try:
-        frchans = subprocess.Popen(
-            ['FrChannels', framefile], stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        out, err = frchans.communicate()
-        if frchans.returncode:
-            raise subprocess.CalledProcessError("FrChannels %s" % framefile)
-    # otherwise manually open the frame and read the ADCs
-    except (OSError, subprocess.CalledProcessError):
-        import lalframe
-        frfile = lalframe.FrameUFrFileOpen(framefile, "r")
-        frtoc = lalframe.FrameUFrTOCRead(frfile)
-        nadc = lalframe.FrameUFrTOCQueryAdcN(frtoc)
-        return [lalframe.FrameUFrTOCQueryAdcName(frtoc, i) for
-                i in range(nadc)]
-    else:
-        return zip(*map(str.split, out.splitlines()))[0]
 
 
 def find_limit_channels(channels, skip=None):
@@ -338,7 +316,7 @@ else:
         raise RuntimeError("No frames recovered for %s in interval [%s, %s)" %
                            (frametype, int(args.gpsstart),
                             int(args.gpsend)))
-    allchannels = get_adc_channels(cache[0].path)
+    allchannels = get_channel_names(cache[0].path)
     print("   Found %d channels in frame" % len(allchannels))
     sys.stdout.flush()
     channels = find_limit_channels(allchannels, skip=args.skip)

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -290,7 +290,7 @@ parser.add_argument('-c', '--channels',
                          "from frames")
 parser.add_argument('-s', '--skip', nargs='*', default=[],
                     help='skip channels matching this string')
-parser.add_argument('-g', '--group-size', default=256, type=int,
+parser.add_argument('-g', '--group-size', default=1024, type=int,
                     help="number of channels to process in a single batch, "
                          "default: %(default)s")
 parser.add_argument('-a', '--state-flag', metavar='FLAG',
@@ -366,7 +366,7 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
         ngroup = args.group_size
     else:
         ngroup = int(
-            min(nchans, args.group_size, .5 * 1024**3 / 4. / 16. / dur))
+            min(nchans, args.group_size, 2 * 1024**3 / 4. / 16. / dur))
     print('Processing %s channels in groups of %d:' % (suffix, ngroup))
     sys.stdout.flush()
     sets = grouper(clist, ngroup)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-cjson
 http://software.ligo.org/lscsoft/source/glue-1.54.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
-gwpy
+gwpy>=0.4

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     'scipy>=0.16',
     'matplotlib>=1.4.1',
     'astropy>=1.2',
-    'gwpy>=0.3',
+    'gwpy>=0.4',
     'trigfind>=0.3',
 ]
 requires = [


### PR DESCRIPTION
This PR introduces a few optimisations for the `gwdetchar-software-saturations` executable, namely:

- increase default maximum size of channel groups to have fewer `TimeSeriesDict.read` calls
- pass `type='adc'` to `TimeSeriesDict.read` to prevent having to parse the TOC for any frames
- use multi-processing when finding saturations in the loaded data

This upgrades the requirement on gwpy to 0.4.