### PR TITLE
Fixed bug in gwdetchar-overflow

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -201,7 +201,7 @@ for dcuid in args.dcuid:
                     for ch in channels:
                         find_overflows(data[ch], ch, seg)
                 gprint("Done")
-            else:
+            elif use_segments:
                 for ch in channels:
                     try:
                         overflows[ch] += DataQualityFlag(ch, known=[seg])


### PR DESCRIPTION
This else case was being activated in cases where we wanted to write to sngl_burst and didn't find any overflows. In such a case, we don't need to do anything, we just leave the sngl_burst table empty. When the code hit this point it was trying to add a DataQualityFlag object to a sngl_burst table, initialized in [line 158](https://github.com/ligovirgo/gwdetchar/blob/master/bin/gwdetchar-overflow#L158), and throwing an error. It's still the right logic for segment-related use cases.