### PR TITLE
Improved gray segment display for matplotlib 2

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -52,7 +52,8 @@ __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
 def plot_overflows(flag, span, facecolor='red', edgecolor='darkred',
-                   known={'alpha': 0.1, 'facecolor': 'lightgray'}):
+                   known={'alpha': 0.2, 'facecolor': 'lightgray',
+                          'edgecolor': 'gray'}):
     """Plot the overflow segments contained within this flag
     """
     plot = flag.plot(figsize=[12, 2], facecolor=facecolor, edgecolor=edgecolor,

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -279,7 +279,8 @@ for i, channel in enumerate(sorted(allchannels)):
             scatter.active = scatter.active.protract(args.segment_padding)
             scatter.coalesce()
         axes['segments'].plot(scatter, facecolor='red', edgecolor='darkred',
-                              known={'alpha': 0.1, 'facecolor': 'lightgray'},
+                              known={'alpha': 0.2, 'facecolor': 'lightgray',
+                                     'edgecolor': 'gray'},
                               y=0, label=' ')
         scatter_segments[channel] += scatter
         if args.verbose:

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -110,7 +110,8 @@ def write_flag_html(flag, id=0, parent='accordion', context='warning',
 
 
 def plot_saturations(flag, span, facecolor='red', edgecolor='darkred',
-                     known={'alpha': 0.2, 'facecolor': 'lightgray'}):
+                     known={'alpha': 0.2, 'facecolor': 'lightgray',
+                            'edgecolor': 'gray'}):
     """Plot the saturation segments contained within this flag
     """
     plot = flag.plot(figsize=[12, 2], facecolor=facecolor, edgecolor=edgecolor,


### PR DESCRIPTION
This PR improves the way that analysis segments are displayed as gray background segments in the following executables

- `gwdetchar-overflow`
- `gwdetchar-scattering`
- `gwdetchar-software-saturations`