### PR TITLE
Add contribution plots and fix scaling and bugs

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -37,7 +37,7 @@ from matplotlib import use
 use('agg')
 import matplotlib.pyplot as plt
 
-from sklearn.linear_model import (Lasso, LassoCV)
+from sklearn import linear_model
 from sklearn.preprocessing import scale
 
 from gwpy.table import Table
@@ -118,7 +118,7 @@ parser.add_argument('-R', '--range-frametype',
                     help='frametype for --range-channel')
 parser.add_argument('-O', '--remove-outliers', type=float, default=None,
                     help='Std. dev. limit for removing outliers')
-parser.add_argument('-t', '--threshold', type=float, default=0.1, 
+parser.add_argument('-t', '--threshold', type=float, default=0.0001, 
                     help='threshold for making a plot')
 
 psig = parser.add_argument_group('Signal processing options')
@@ -192,24 +192,48 @@ auxdata = TimeSeriesDict.get(
     frametype=frametype, nproc=args.nproc,
     observatory=args.ifo[0], pad=0, **io_kw)
 
+# -- removes flat data to be re-introdused later
+
+flatdata = dict()
+gooddata = dict()
+
+goodchan = list()
+
+for k, ts in auxdata.items():
+	flat = ts.value.min() == ts.value.max()
+	if flat:
+		flatdata[k] = ts
+	else:
+		gooddata[k] = ts
+		goodchan.append(k)
+
+auxdata = gooddata
+        
+data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
 # -- perform LASSO regression -------------------------------------------------
 
 # create model
 if args.alpha is None:
-    model = LassoCV()
+	model = linear_model.LassoCV()
 else:
-    model = Lasso(args.alpha)
-
-# reformat auxiliary data
-data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
+	model = linear_model.Lasso(args.alpha)
 
 # perform LASSO regression fit
 model.fit(data, scale(rangets.value))
 
+
+#pulls out alphas
+usedalpha = 0
+if args.alpha is None:
+	usedalpha = model.alpha_
+else:
+	usedalpha = args.alpha
+
+
 # restructure results for convenience
 unsortedResults=[]
-for n in range (0,len(channels)):
-	unsortedResults.append([channels[n], model.coef_[n]])
+for n, k in enumerate(auxdata.keys()):
+	unsortedResults.append([k, model.coef_[n]])
 
 unsortedResults=sorted(unsortedResults, key=lambda x: abs(x[1]), reverse=True)
 sortedResults=[[x[0] for x in unsortedResults],[y[1] for y in unsortedResults]]
@@ -229,6 +253,7 @@ print(useful)
 
 resultstab.write('resultstab.txt',format='ascii')
 df = useful.to_pandas()
+df.index+=1
 
 #-- Process aux channels, making plots
 print("-- Processing channels")
@@ -248,18 +273,25 @@ def process_channel(input_,):
     chan, ts = input_
     flat = ts.value.min() == ts.value.max()
     if flat:
-        lassocoef = None
+        lassocoef = 0.0
         plot1 = None
         plot2 = None
+        plot3 = None
+        pcorr= None
     else:
         lassocoef = model.coef_[modelIndex]
         plot1 = None
         plot2 = None
-        if(numpy.absolute(lassocoef) < args.threshold):
+        if args.trend_type == 'minute':
+            pcorr = numpy.corrcoef(ts.value, rangets.value)[0, 1]
+        else:
+            pcorr = 0.0
+        if(abs(lassocoef) < args.threshold):
             plot1 = None
             plot2 = None
+	    plot3 = None
             modelIndex+=1
-            return chan, lassocoef, plot1, plot2
+            return chan, lassocoef, plot1, plot2, plot3, ts
         # -- Create time series subplot
         plot = TimeSeriesPlot(rangets, ts, sep=True, sharex=True,
                               figsize=(12, 12))
@@ -285,34 +317,64 @@ def process_channel(input_,):
            
         
         # Create scaled, sign-corrected, and overlayed timeseries
-        tsscaled = ts.detrend()
-        tsrms = numpy.sqrt(sum(tsscaled**2.0)/len(tsscaled))
-        if args.trend_type == 'minute':
-            tsscaled *= (rangerms / tsrms)
-            if lassocoef < 0:
-                tsscaled *= -1
 
-        plot = TimeSeriesPlot(rangescaled, tsscaled,
-                              figsize=[12, 6])
-        plot.subplots_adjust(*p2)
-        ax = plot.gca()
-        ax.set_xlim(start, end)
-        ax.set_epoch(start)
-        ax.set_ylabel('Scaled amplitude [arbitrary units]')
-        ax.legend(loc='best')
+	tsscaled = scale(ts.value)
+	if lassocoef < 0:
+                tsscaled = numpy.negative(tsscaled)
+	fig = plt.figure(figsize=(12,6))
+	plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+	plt.plot(tsscaled, label=chan.replace("_","\_"))
+	plt.xlabel('Time [min]')
+	plt.ylabel('Scaled amplitude [arbitrary units]')
+	plt.legend(loc='best')
+	plt.tight_layout()
+
         plot2 = '%s_COMPARISON-%s.png' % (channelstub, gpsstub)
         try:
-            plot.save(plot2)
+            plt.savefig(plot2)
         except (IOError, IndexError):
-            plot.save(plot2)
+            plt.savefig(plot2)
         except RuntimeError as e:
             if 'latex' in str(e).lower():
-                plot.save(plot2)
+                plt.savefig(plot2)
             else:
                 raise
-        plot.close()
-        modelIndex+=1        
+        plt.close()
 
+        #plot scatter plots
+        rangeColor="red"
+        plotHeight=6
+        plotWidth=12
+
+        tsCopy=ts.reshape(-1,1)
+        rangetsCopy=rangets.reshape(-1,1)
+        rangeReg = linear_model.LinearRegression()
+        rangeReg.fit(tsCopy, rangetsCopy)
+        rangeFit = rangeReg.predict(tsCopy)
+        scatPlot=gwplot()
+        axes = scatPlot.gca()
+        axes.set_xlabel(chan.replace("_","\_") + " [Channel units]", labelpad=30)
+        axes.set_ylabel("Sensitive range [Mpc]")
+        axes.text(.9,.1,"r = " + str('{0:.2}'.format(pcorr)), verticalalignment='bottom', horizontalalignment='right', transform=axes.transAxes, color="black", size=20, bbox=dict(boxstyle='square', facecolor='white', alpha=.75, edgecolor="black"))
+        scatPlot.add_scatter(ts, rangets, color=rangeColor)
+        scatPlot.add_line(ts, rangeFit, color="black")
+        scatPlot.set_figheight(plotHeight)
+        scatPlot.set_figwidth(plotWidth)
+	scatPlot.tight_layout()
+
+        plot3 = '%s_SCATTER-%s.png' % (channelstub, gpsstub)
+	try:
+            scatPlot.save(plot3)
+        except (IOError, IndexError):
+            scatPlot.save(plot3)
+        except RuntimeError as e:
+            if 'latex' in str(e).lower():
+                scatPlot.save(plot3)
+            else:
+                raise
+
+        scatPlot.close()
+	modelIndex+=1          
     # increment counter and print status
     with counter.get_lock():
         counter.value += 1
@@ -320,7 +382,7 @@ def process_channel(input_,):
         print("Completed [%d/%d] %3d%% %-50s"
               % (counter.value, nchan, pc, '(%s)' % str(chan)), end='\r')
         sys.stdout.flush()
-    return chan, lassocoef, plot1, plot2
+    return chan, lassocoef, plot1, plot2, plot3, ts
 
 # -- generate LASSO plots
 modelFit=model.predict(data)
@@ -349,19 +411,29 @@ plt.close()
 # -- process channels
 pool = multiprocessing.Pool(nprocplot)
 results = pool.map(process_channel, auxdata.iteritems())
-
+	
 # sort results by the lasso coefficient
 results=sorted(results, key=lambda x: abs(x[1]), reverse=True)
 
+for k in flatdata.keys():
+	results.append((k, None, None, None, None, None))
+
 #plot channel contributions to range
-fig = plt.figure(figsize=(6,6))
+fig = plt.figure(figsize=(12,6))
 plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+plt.plot(scale(results[0][5].value)*results[0][1], label = "Channel 1")
+for n in range(1,len(useful)):
+	summation=scale(results[0][5].value)*results[0][1]
+	for m in range(n,0,-1):
+		summation=numpy.add(summation,scale(results[m][5].value)*results[m][1])
+	plt.plot(summation, label = "Channels 1-" + str(n+1))
 plt.xlabel('Time [min]')
 plt.ylabel('Scaled arbitrary units')
+plt.title('Summations of Channel Contributions to Range')
 plt.legend(loc='best')
 plt.tight_layout()
 
-plot5 = 'CHANNEL-CONTRIBUTIONS-TO-RANGE-%s.png' % gpsstub
+plot5 = 'SUMMATION-OF-CHANNELS-AND-RANGE-%s.png' % gpsstub
 
 try:
         plt.savefig(plot5)
@@ -375,7 +447,31 @@ except RuntimeError as e:
 
 plt.close()
 
+fig = plt.figure(figsize=(12,6))
+plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+for n in range (0, len(useful)):
+	if results[n][5] is not None:
+	        plt.plot(scale(results[n][5].value)*results[n][1], label = results[n][0].replace("_","\_"))
 
+plt.xlabel('Time [min]')
+plt.ylabel('Scaled arbitrary units')
+plt.title('Individual Channel Contributions to Range')
+plt.legend(loc='best')
+plt.tight_layout()
+
+plot6 = 'CHANNEL-CONTRIBUTIONS-TO-RANGE-%s.png' % gpsstub
+
+try:
+        plt.savefig(plot6)
+except (IOError, IndexError):
+        plt.savefig(plot6)
+except RuntimeError as e:
+        if 'latex' in str(e).lower():
+                plt.savefig(plot6)
+        else:
+                raise
+
+plt.close()
 
 # -- write html
 title = '%s LASSO slow correlations: %d-%d' % (args.ifo, start, end)
@@ -386,10 +482,10 @@ page.div(class_='page-header')
 page.h1(title)
 if args.alpha is None:
     page.p("This analysis searched %d channels and created a LASSO regression model for %s using LASSO CV."
-       % (nchan, rangechannel, args.alpha))
+       % (nchan, rangechannel))
 else:
     page.p("This analysis searched %d channels and created a LASSO regression model for %s with an alpha of %s."
-       % (nchan, rangechannel, args.alpha))
+       % (nchan, rangechannel, usedalpha))
 page.div.close()#page-header
 
 # results
@@ -406,22 +502,26 @@ page.a.close()#range lasso plot
 page.div.close()#range-lasso
 
 page.div(class_='model-info', style_='display: inline-block;')
-page.p('<font size ="4">Model: LASSO<br />Non-zero coefficients: %d<br />Alpha: %g</font>' % (len(useful), args.alpha))
+page.p('<font size ="4">Model: LASSO<br />Non-zero coefficients: %d<br />Alpha: %g</font>' % (numpy.count_nonzero(model.coef_), usedalpha))
+page.p('<br /><br />%s' % df.to_html(index=True))
 page.div.close()#model-info
 
 page.div.close()#close inline-block
 
-page.div(style_='display: inline-block;')
-page.div(class_='channel-list', style_='display: inline-block;')
-page.p('<br /><br />%s<br /><br />' % df.to_html(index=False))
-page.div.close()#channel-list
+page.p('<br /><br />')
 
-page.div(class_='channels-and-range', style_='display: inline-block;')
+page.div(class_='channel-summation')
 page.a(href=plot5, target='_blank')
-page.img(class_='channels-contrib-img', src=plot5)
+page.img(class_='channels-summation-img', src=plot5)
+page.a.close()#channels-summation plot
+page.div.close()#channels-summation
+
+page.div(class_='channels-and-range')
+page.a(href=plot6, target='_blank')
+page.img(class_='channels-contrib-img', src=plot6)
 page.a.close()#channels-contrib plot
 page.div.close()#channels-and-range
-page.div.close()#close inline-block
+
 
 page.div.close()#model-body
 page.div.close()#model
@@ -432,7 +532,7 @@ page.h2('Top Channels')
 page.div(class_='panel-group', id_='results')
 
 # for each auxiliary channel create information container and put plots in it
-for i, (ch, lassocoef, plot1, plot2) in enumerate(results):
+for i, (ch, lassocoef, plot1, plot2, plot3, ts) in enumerate(results):
     # Set container color/context based on lasso coefficient
     if lassocoef is None:
         h = '%s [flat]' % ch
@@ -463,7 +563,7 @@ for i, (ch, lassocoef, plot1, plot2) in enumerate(results):
     elif plot1 is None:
         page.p("LASSO coefficient below the threshold of %.2f." %(args.threshold))
     else:
-        for p in (plot1, plot2):
+        for p in (plot1, plot2, plot3):
             page.a(href=p, target='_blank')
             page.img(class_='img-responsive', src=p)
             page.a.close()

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -200,12 +200,12 @@ gooddata = dict()
 goodchan = list()
 
 for k, ts in auxdata.items():
-	flat = ts.value.min() == ts.value.max()
-	if flat:
-		flatdata[k] = ts
-	else:
-		gooddata[k] = ts
-		goodchan.append(k)
+    flat = ts.value.min() == ts.value.max()
+    if flat:
+        flatdata[k] = ts
+    else:
+        gooddata[k] = ts
+        goodchan.append(k)
 
 auxdata = gooddata
         
@@ -214,9 +214,9 @@ data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
 
 # create model
 if args.alpha is None:
-	model = linear_model.LassoCV()
+    model = linear_model.LassoCV()
 else:
-	model = linear_model.Lasso(args.alpha)
+    model = linear_model.Lasso(args.alpha)
 
 # perform LASSO regression fit
 model.fit(data, scale(rangets.value))
@@ -225,15 +225,15 @@ model.fit(data, scale(rangets.value))
 #pulls out alphas
 usedalpha = 0
 if args.alpha is None:
-	usedalpha = model.alpha_
+    usedalpha = model.alpha_
 else:
-	usedalpha = args.alpha
+    usedalpha = args.alpha
 
 
 # restructure results for convenience
 unsortedResults=[]
 for n, k in enumerate(auxdata.keys()):
-	unsortedResults.append([k, model.coef_[n]])
+    unsortedResults.append([k, model.coef_[n]])
 
 unsortedResults=sorted(unsortedResults, key=lambda x: abs(x[1]), reverse=True)
 sortedResults=[[x[0] for x in unsortedResults],[y[1] for y in unsortedResults]]
@@ -243,7 +243,7 @@ resultstab = Table(data=(sortedResults[0],sortedResults[1]),
 
 i=0
 while(i<len(resultstab['LASSO Coefficient']) and abs(resultstab['LASSO Coefficient'][i])>=args.threshold):
-	i+=1
+    i+=1
 useful=Table(data=(resultstab['Channel'][0:i],resultstab['LASSO Coefficient'][0:i]), names =('Channel', 'LASSO Coefficient'))
 
 # print results
@@ -266,11 +266,10 @@ form = '%%.%dd' % len(str(nchan))
 p1 = (.1, .1, .9, .95) # global plot defaults for plot1, timeseries subplots
 p2 = (.1, .15, .9, .9) # global plot defaults for plot2, timeseries overlay
 
-modelIndex=0
+def process_channel(input_,):
+    chan = input_[1][0]
+    ts = input_[1][1]
 
-def process_channel(input_,):  
-    global modelIndex
-    chan, ts = input_
     flat = ts.value.min() == ts.value.max()
     if flat:
         lassocoef = 0.0
@@ -279,7 +278,7 @@ def process_channel(input_,):
         plot3 = None
         pcorr= None
     else:
-        lassocoef = model.coef_[modelIndex]
+        lassocoef = model.coef_[input_[0]]
         plot1 = None
         plot2 = None
         if args.trend_type == 'minute':
@@ -290,7 +289,6 @@ def process_channel(input_,):
             plot1 = None
             plot2 = None
 	    plot3 = None
-            modelIndex+=1
             return chan, lassocoef, plot1, plot2, plot3, ts
         # -- Create time series subplot
         plot = TimeSeriesPlot(rangets, ts, sep=True, sharex=True,
@@ -320,7 +318,7 @@ def process_channel(input_,):
 
 	tsscaled = scale(ts.value)
 	if lassocoef < 0:
-                tsscaled = numpy.negative(tsscaled)
+            tsscaled = numpy.negative(tsscaled)
 	fig = plt.figure(figsize=(12,6))
 	plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
 	plt.plot(tsscaled, label=chan.replace("_","\_"))
@@ -374,7 +372,7 @@ def process_channel(input_,):
                 raise
 
         scatPlot.close()
-	modelIndex+=1          
+          
     # increment counter and print status
     with counter.get_lock():
         counter.value += 1
@@ -397,36 +395,37 @@ plt.tight_layout()
 plot4 = 'LASSO-MODEL-%s.png' % gpsstub
 
 try:
-	plt.savefig(plot4)
+    plt.savefig(plot4)
 except (IOError, IndexError):
-	plt.savefig(plot4)
+    plt.savefig(plot4)
 except RuntimeError as e:
-	if 'latex' in str(e).lower():
-		plt.savefig(plot4)
-	else:
-		raise
+    if 'latex' in str(e).lower():
+        plt.savefig(plot4)
+    else:
+        raise
 
 plt.close()
 
 # -- process channels
 pool = multiprocessing.Pool(nprocplot)
-results = pool.map(process_channel, auxdata.iteritems())
+results = pool.map(process_channel, enumerate(auxdata.iteritems()))
+#results = pool.map(process_channel, enumerate(auxdata))
 	
 # sort results by the lasso coefficient
 results=sorted(results, key=lambda x: abs(x[1]), reverse=True)
 
 for k in flatdata.keys():
-	results.append((k, None, None, None, None, None))
+    results.append((k, None, None, None, None, None))
 
 #plot channel contributions to range
 fig = plt.figure(figsize=(12,6))
 plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
 plt.plot(scale(results[0][5].value)*results[0][1], label = "Channel 1")
 for n in range(1,len(useful)):
-	summation=scale(results[0][5].value)*results[0][1]
-	for m in range(n,0,-1):
-		summation=numpy.add(summation,scale(results[m][5].value)*results[m][1])
-	plt.plot(summation, label = "Channels 1-" + str(n+1))
+    summation=scale(results[0][5].value)*results[0][1]
+    for m in range(n,0,-1):
+        summation=numpy.add(summation,scale(results[m][5].value)*results[m][1])
+    plt.plot(summation, label = "Channels 1-" + str(n+1))
 plt.xlabel('Time [min]')
 plt.ylabel('Scaled arbitrary units')
 plt.title('Summations of Channel Contributions to Range')
@@ -436,22 +435,22 @@ plt.tight_layout()
 plot5 = 'SUMMATION-OF-CHANNELS-AND-RANGE-%s.png' % gpsstub
 
 try:
-        plt.savefig(plot5)
+    plt.savefig(plot5)
 except (IOError, IndexError):
-        plt.savefig(plot5)
+    plt.savefig(plot5)
 except RuntimeError as e:
-        if 'latex' in str(e).lower():
-                plt.savefig(plot5)
-        else:
-                raise
+    if 'latex' in str(e).lower():
+        plt.savefig(plot5)
+    else:
+        raise
 
 plt.close()
 
 fig = plt.figure(figsize=(12,6))
 plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
 for n in range (0, len(useful)):
-	if results[n][5] is not None:
-	        plt.plot(scale(results[n][5].value)*results[n][1], label = results[n][0].replace("_","\_"))
+    if results[n][5] is not None:
+        plt.plot(scale(results[n][5].value)*results[n][1], label = results[n][0].replace("_","\_"))
 
 plt.xlabel('Time [min]')
 plt.ylabel('Scaled arbitrary units')
@@ -462,14 +461,14 @@ plt.tight_layout()
 plot6 = 'CHANNEL-CONTRIBUTIONS-TO-RANGE-%s.png' % gpsstub
 
 try:
-        plt.savefig(plot6)
+    plt.savefig(plot6)
 except (IOError, IndexError):
-        plt.savefig(plot6)
+    plt.savefig(plot6)
 except RuntimeError as e:
-        if 'latex' in str(e).lower():
-                plt.savefig(plot6)
-        else:
-                raise
+    if 'latex' in str(e).lower():
+        plt.savefig(plot6)
+    else:
+        raise
 
 plt.close()
 

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -5,16 +5,6 @@
 # This file is part of the GW DetChar python package.
 #
 # GW DetChar is free software: you can redistribute it and/or modify
-#it under terms of Copyright (C) LIGO Scientific Collaboration (2015-)
-#
-# This file is part of the GW DetChar python package.
-#
-# GW DetChar is free software: you can redistribute it and/or modify
-# it under the terms of topyright (C) LIGO Scientific Collaboration (2015-)
-#
-# This file is part of the GW DetChar python package.
-#
-# GW DetChar is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -29,6 +29,7 @@ import re
 import multiprocessing
 import sys
 
+from math import isnan
 import numpy
 from scipy.stats import spearmanr
 from scipy.interpolate import UnivariateSpline
@@ -208,8 +209,30 @@ for k, ts in auxdata.items():
         goodchan.append(k)
 
 auxdata = gooddata
+
+nandata = dict()
+gooddata = dict()
+
+goodchan = list()
+
+try:
+    data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
+except:
+    print('Nan found in data, removing bad channels')
+    for k, v in auxdata.items():
+        hasnan = 0
+        for x in range(len(v.value)):
+            if isnan(v.value[x]):
+                hasnan +=1
+        if hasnan > 0:
+            print('removing channel: %s' % k)
+            nandata[k] = v
+        else:
+            gooddata[k] = v
+            goodchan.append(k)
+    auxdata = gooddata
+    data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
         
-data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
 # -- perform LASSO regression -------------------------------------------------
 
 # create model
@@ -385,11 +408,12 @@ def process_channel(input_,):
 # -- generate LASSO plots
 modelFit=model.predict(data)
 
-fig = plt.figure(figsize=(6,6))
+fig = plt.figure(figsize=(12,6))
 plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
 plt.plot(modelFit, label='LASSO model')
 plt.xlabel('Time [min]')
 plt.ylabel('Scaled arbitrary units')
+plt.title('LASSO Model of Range')
 plt.legend(loc='best')
 plt.tight_layout()
 plot4 = 'LASSO-MODEL-%s.png' % gpsstub
@@ -492,22 +516,19 @@ page.h2('Model Information')
 
 page.div(class_='model')
 page.div(class_='model-body')
-page.div(style_='display: inline-block;')
-
-page.div(class_='range-lasso', style_='display: inline-block;')
-page.a(href=plot4, target='_blank')
-page.img(class_='lasso-img', src=plot4)
-page.a.close()#range lasso plot
-page.div.close()#range-lasso
 
 page.div(class_='model-info', style_='display: inline-block;')
 page.p('<font size ="4">Model: LASSO<br />Non-zero coefficients: %d<br />Alpha: %g</font>' % (numpy.count_nonzero(model.coef_), usedalpha))
 page.p('<br /><br />%s' % df.to_html(index=True))
 page.div.close()#model-info
 
-page.div.close()#close inline-block
-
 page.p('<br /><br />')
+
+page.div(class_='range-lasso', style_='display: inline-block;')
+page.a(href=plot4, target='_blank')
+page.img(class_='lasso-img', src=plot4)
+page.a.close()#range lasso plot
+page.div.close()#range-lasso)
 
 page.div(class_='channel-summation')
 page.a(href=plot5, target='_blank')
@@ -536,9 +557,9 @@ for i, (ch, lassocoef, plot1, plot2, plot3, ts) in enumerate(results):
     if lassocoef is None:
         h = '%s [flat]' % ch
     elif plot1 is None:
-        h = '%s [lasso coefficient = %.2f] (Below threshold)' % (ch, lassocoef)
+        h = '%s [lasso coefficient = %.4f] (Below threshold)' % (ch, lassocoef)
     else:
-        h = '%s [lasso coefficient = %.2f]' % (ch, lassocoef)
+        h = '%s [lasso coefficient = %.4f]' % (ch, lassocoef)
     if (lassocoef is None) or (lassocoef == 0) or (plot1 is None):
         context = 'panel-default'
     elif(numpy.absolute(lassocoef) >= .5):

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -5,6 +5,11 @@
 # This file is part of the GW DetChar python package.
 #
 # GW DetChar is free software: you can redistribute it and/or modify
+#it under terms of Copyright (C) LIGO Scientific Collaboration (2015-)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
 # it under the terms of topyright (C) LIGO Scientific Collaboration (2015-)
 #
 # This file is part of the GW DetChar python package.
@@ -37,6 +42,7 @@ from scipy.interpolate import UnivariateSpline
 from matplotlib import use
 use('agg')
 import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
 
 from sklearn import linear_model
 from sklearn.preprocessing import scale
@@ -132,6 +138,10 @@ psig.add_argument('-x', '--filter-padding', type=float, default=3.,
 lsig = parser.add_argument_group('LASSO options')
 lsig.add_argument('-a', '--alpha', default=None, type=float,
                   help='alpha parameter for LASSO fit')
+lsig.add_argument('-C', '--cluster', default=True, type=bool,
+                  help='generate clustered channel plots')
+lsig.add_argument('-c', '--cluster-coefficient', default=.85, type=float,
+                  help='correlation coefficient threshold for clustering')
 
 args = parser.parse_args()
 
@@ -198,7 +208,7 @@ auxdata = TimeSeriesDict.get(
 flatdata = dict()
 gooddata = dict()
 
-goodchan = list()
+#goodchan = list()
 
 for k, ts in auxdata.items():
     flat = ts.value.min() == ts.value.max()
@@ -206,14 +216,11 @@ for k, ts in auxdata.items():
         flatdata[k] = ts
     else:
         gooddata[k] = ts
-        goodchan.append(k)
 
 auxdata = gooddata
 
 nandata = dict()
 gooddata = dict()
-
-goodchan = list()
 
 try:
     data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
@@ -229,7 +236,6 @@ except:
             nandata[k] = v
         else:
             gooddata[k] = v
-            goodchan.append(k)
     auxdata = gooddata
     data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
         
@@ -269,12 +275,24 @@ while(i<len(resultstab['LASSO Coefficient']) and abs(resultstab['LASSO Coefficie
     i+=1
 useful=Table(data=(resultstab['Channel'][0:i],resultstab['LASSO Coefficient'][0:i]), names =('Channel', 'LASSO Coefficient'))
 
+zeroed = resultstab['LASSO Coefficient'] == 0
+zeroedResults=Table(data=(resultstab[zeroed]['Channel'],), names =('Channels',))
+
+flatResults=Table(data = (numpy.asarray(flatdata.keys()),), names = ('Channels',))
+
 # print results
 print('Found {} channels with |LASSO Coefficient| >= {}'.format(
     len(useful), args.threshold))
 print(useful)
 
-resultstab.write('resultstab.txt',format='ascii')
+gpsstub = '%d-%d' % (start, end-start)
+zeroFile = '%s-ZERO_COEFFICIENT_CHANNELS-%s.txt'% (args.ifo, gpsstub)
+flatFile = '%s-FLAT_CHANNELS-%s.txt'% (args.ifo, gpsstub)
+
+resultstab.write('resultstab.txt', format='ascii')
+zeroedResults.write(zeroFile, format='ascii')
+flatResults.write(flatFile, format='ascii')
+
 df = useful.to_pandas()
 df.index+=1
 
@@ -282,7 +300,6 @@ df.index+=1
 print("-- Processing channels")
 counter = multiprocessing.Value('i', 0)
 
-gpsstub = '%d-%d' % (start, end-start)
 re_delim = re.compile('[:_-]')
 form = '%%.%dd' % len(str(nchan))
 
@@ -292,14 +309,14 @@ p2 = (.1, .15, .9, .9) # global plot defaults for plot2, timeseries overlay
 def process_channel(input_,):
     chan = input_[1][0]
     ts = input_[1][1]
+    zeroed = model.coef_[input_[0]] == 0
 
-    flat = ts.value.min() == ts.value.max()
-    if flat:
-        lassocoef = 0.0
+    if zeroed:
+        lassocoef = 0
         plot1 = None
         plot2 = None
         plot3 = None
-        pcorr= None
+        pcorr = None
     else:
         lassocoef = model.coef_[input_[0]]
         plot1 = None
@@ -433,27 +450,35 @@ plt.close()
 # -- process channels
 pool = multiprocessing.Pool(nprocplot)
 results = pool.map(process_channel, enumerate(auxdata.iteritems()))
-#results = pool.map(process_channel, enumerate(auxdata))
 	
 # sort results by the lasso coefficient
 results=sorted(results, key=lambda x: abs(x[1]), reverse=True)
 
-for k in flatdata.keys():
-    results.append((k, None, None, None, None, None))
+# generate plots for channel contribution to model
+colors = []
+labels = []
+fig = plt.figure(figsize=(8,5))
+ax = plt.subplot(111)
 
-#plot channel contributions to range
-fig = plt.figure(figsize=(12,6))
-plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
-plt.plot(scale(results[0][5].value)*results[0][1], label = "Channel 1")
+line1 = plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+colors.append(line1[0].get_color())
+labels.append(line1[0].get_label())
+
+line2=plt.plot(scale(results[0][5].value)*results[0][1], label = "Channel 1")
+colors.append(line2[0].get_color())
+labels.append(line2[0].get_label())
+
 for n in range(1,len(useful)):
     summation=scale(results[0][5].value)*results[0][1]
     for m in range(n,0,-1):
         summation=numpy.add(summation,scale(results[m][5].value)*results[m][1])
-    plt.plot(summation, label = "Channels 1-" + str(n+1))
+    line = plt.plot(summation, label = "Channels 1-" + str(n+1))
+    colors.append(line[0].get_color())
+    labels.append(line[0].get_label())
+
 plt.xlabel('Time [min]')
 plt.ylabel('Scaled arbitrary units')
 plt.title('Summations of Channel Contributions to Range')
-plt.legend(loc='best')
 plt.tight_layout()
 
 plot5 = 'SUMMATION-OF-CHANNELS-AND-RANGE-%s.png' % gpsstub
@@ -470,16 +495,46 @@ except RuntimeError as e:
 
 plt.close()
 
-fig = plt.figure(figsize=(12,6))
-plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+legend_fig =  plt.figure()
+patches = [
+    Patch(color=color, label=label)
+    for label, color in zip(labels, colors)]
+legend = legend_fig.legend(patches, labels, loc = 'center', frameon=False, fontsize= 'small')
+legend_fig.canvas.draw()
+
+plot5_legend = 'SUMMATION-OF-CHANNELS-AND-RANGE-%s-LEGEND.png' % gpsstub
+
+try:
+    legend_fig.savefig(plot5_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+except (IOError, IndexError):
+    legend_fig.savefig(plot5_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+except RuntimeError as e:
+    if 'latex' in str(e).lower():
+        legend_fig.savefig(plot5_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+    else:
+        raise
+
+plt.close()
+
+
+colors = []
+labels = []
+fig = plt.figure(figsize=(8,5))
+ax = plt.subplot(111)
+line = plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+colors.append(line[0].get_color())
+labels.append(line[0].get_label())
+
+
 for n in range (0, len(useful)):
     if results[n][5] is not None:
-        plt.plot(scale(results[n][5].value)*results[n][1], label = results[n][0].replace("_","\_"))
+        line = plt.plot(scale(results[n][5].value)*results[n][1], label = results[n][0].replace("_","\_"))
+        colors.append(line[0].get_color())
+        labels.append(line[0].get_label())
 
 plt.xlabel('Time [min]')
 plt.ylabel('Scaled arbitrary units')
 plt.title('Individual Channel Contributions to Range')
-plt.legend(loc='best')
 plt.tight_layout()
 
 plot6 = 'CHANNEL-CONTRIBUTIONS-TO-RANGE-%s.png' % gpsstub
@@ -496,6 +551,121 @@ except RuntimeError as e:
 
 plt.close()
 
+legend_fig =  plt.figure()
+patches = [
+    Patch(color=color, label=label)
+    for label, color in zip(labels, colors)]
+legend = legend_fig.legend(patches, labels, loc = 'center', frameon=False, fontsize = 'small')
+legend_fig.canvas.draw()
+
+plot6_legend = 'CHANNEL-CONTRIBUTIONS-TO-RANGE-%s-LEGEND.png' % gpsstub
+
+try:
+    legend_fig.savefig(plot6_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+except (IOError, IndexError):
+    legend_fig.savefig(plot6_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+except RuntimeError as e:
+    if 'latex' in str(e).lower():
+        legend_fig.savefig(plot6_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+    else:
+        raise
+
+plt.close()
+
+
+# -- generate clustered time series plots
+
+counter = multiprocessing.Value('i', 0)
+def generate_clusters(input_,):
+    currentchan = input_[1][0]
+    currentts = input_[1][5]
+    current = input_[0]
+    clusterThreshold = args.cluster_coefficient
+    plot7 = None
+    plot7_legend = None
+
+    if current < len(useful):
+        currentCluster = []
+        other = 0
+        while other < len(results):
+            otherts = results[other][5]
+            if current != other:
+                pcorr = numpy.corrcoef(currentts.value, otherts.value)[0,1]
+                if(abs(pcorr)>=clusterThreshold):
+                    chan = results[other][0]
+                    channelstub = re_delim.sub('_', str(chan)).replace('_', '-', 1)
+                    currentCluster.append([other, otherts, pcorr, chan, channelstub])
+            other+=1
+        if len(currentCluster) == 0:
+            return plot7, plot7_legend
+        else: 
+            colors = []
+            labels = []
+            fig = plt.figure(figsize=(8,5))
+            ax = plt.subplot(111)
+            line = plt.plot(scale(currentts.value)*numpy.sign(input_[1][1]), label=currentchan.replace("_","\_"))
+            colors.append(line[0].get_color())
+            labels.append(line[0].get_label())
+            currentCluster = sorted(currentCluster, key=lambda x: abs(x[2]), reverse=True)
+
+            for i in range (0, len(currentCluster)):
+                line = plt.plot(scale(currentCluster[i][1].value)*numpy.sign(input_[1][1])*numpy.sign(currentCluster[i][2]), label=currentCluster[i][3].replace("_","\_") + ', r = ' + str('{0:.2}'.format(currentCluster[i][2])))
+                colors.append(line[0].get_color())
+                labels.append(line[0].get_label())
+	    plt.xlabel('Time [min]')
+	    plt.ylabel('Scaled amplitude [arbitrary units]')
+            plt.title('Highly Correlated Channels')
+	    plt.tight_layout()
+
+            plot7 = '%s_CLUSTER-%s.png' % (re_delim.sub('_', str(currentchan)).replace('_', '-', 1), gpsstub)
+            try:
+                plt.savefig(plot7)
+            except (IOError, IndexError):
+                plt.savefig(plot7)
+            except RuntimeError as e:
+                if 'latex' in str(e).lower():
+                    plt.savefig(plot7)
+                else:
+                    raise
+            plt.close()
+
+            legend_fig =  plt.figure()
+            patches = [
+                Patch(color=color, label=label)
+                for label, color in zip(labels, colors)]
+            legend = legend_fig.legend(patches, labels, loc = 'center', frameon=False, fontsize= 'small')
+            legend_fig.canvas.draw()
+
+            plot7_legend = '%s_CLUSTER-%s-LEGEND.png' % (re_delim.sub('_', str(currentchan)).replace('_', '-', 1), gpsstub)
+
+            try:
+                legend_fig.savefig(plot7_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+            except (IOError, IndexError):
+                legend_fig.savefig(plot5_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+            except RuntimeError as e:
+                if 'latex' in str(e).lower():
+                    legend_fig.savefig(plot5_legend, bbox_inches=legend.get_window_extent().transformed(legend_fig.dpi_scale_trans.inverted()))
+                else:
+                    raise
+
+            plt.close()
+
+    with counter.get_lock():
+        counter.value += 1
+        pc = 100 * counter.value / nchan
+        print("Completed [%d/%d] %3d%% %-50s"
+              % (counter.value, nchan, pc, '(%s)' % str(currentchan)), end='\r')
+        sys.stdout.flush()
+
+    return plot7, plot7_legend
+
+
+if args.cluster is True:
+    print("-- Generating clusters")
+    pool = multiprocessing.Pool(nprocplot)
+    clusters = pool.map(generate_clusters, enumerate(results[0:len(useful)]))
+
+
 # -- write html
 title = '%s LASSO slow correlations: %d-%d' % (args.ifo, start, end)
 page = html.new_bootstrap_page(title=title)
@@ -503,43 +673,71 @@ page.div(class_='container')
 
 page.div(class_='page-header')
 page.h1(title)
-if args.alpha is None:
-    page.p("This analysis searched %d channels and created a LASSO regression model for %s using LASSO CV."
-       % (nchan, rangechannel))
-else:
-    page.p("This analysis searched %d channels and created a LASSO regression model for %s with an alpha of %s."
-       % (nchan, rangechannel, usedalpha))
 page.div.close()#page-header
 
-# results
+# params
+def write_param(param, value):
+    page.p()
+    page.strong('%s: ' % param)
+    page.add(str(value))
+    page.p.close()
+
+page.h2('Parameters')
+page.p('This analysis used the following parameters:')
+write_param('Start time', '%s (%d)' % (from_gps(start), start))
+write_param('End time', '%s (%d)' % (from_gps(end), end))
+write_param('Range channel',
+            '%s (%s)' % (rangechannel, args.range_frametype or '-'))
+write_param('Channels searched', '%d' % nchan)
+write_param('Number of flat channels', '%d (%s)' % (len(flatdata), "<a href= %s target='_blank'>flat channel list</a>" % (flatFile)))
+write_param('LASSO coefficient threshold', '%g' % args.threshold)
+
 page.h2('Model Information')
 
 page.div(class_='model')
 page.div(class_='model-body')
 
-page.div(class_='model-info', style_='display: inline-block;')
-page.p('<font size ="4">Model: LASSO<br />Non-zero coefficients: %d<br />Alpha: %g</font>' % (numpy.count_nonzero(model.coef_), usedalpha))
+page.div(class_='model-info')
+page.p('<font size ="4">Model: LASSO<br />Non-zero coefficients: %d<br />Alpha: %g<br />Zero coefficients: %d (%s)</font>' % (numpy.count_nonzero(model.coef_), usedalpha, len(zeroedResults), "<a href= %s target='_blank'>zeroed channel list</a>" % (zeroFile)))
 page.p('<br /><br />%s' % df.to_html(index=True))
 page.div.close()#model-info
 
 page.p('<br /><br />')
 
-page.div(class_='range-lasso', style_='display: inline-block;')
+page.div(class_='range-lasso')
 page.a(href=plot4, target='_blank')
 page.img(class_='lasso-img', src=plot4)
 page.a.close()#range lasso plot
 page.div.close()#range-lasso)
 
-page.div(class_='channel-summation')
+page.div(class_='channel-summation', style_='display: flex;flex-wrap:nowrap;justify-content:space-around;')
+page.div(style_='display: block;')
 page.a(href=plot5, target='_blank')
 page.img(class_='channels-summation-img', src=plot5)
 page.a.close()#channels-summation plot
+page.div.close()#close plot5 div
+page.div(class_='scroll-container', style_='display: block; padding-top: 40px;')
+page.div(style_='display: block; overflow:auto; height:400px;')
+page.a(href=plot5_legend, target='_blank')
+page.img(class_='channels-contrib-img', src=plot5_legend)
+page.a.close()#legend image
+page.div.close()#overflowed window
+page.div.close()#scroll container
 page.div.close()#channels-summation
 
-page.div(class_='channels-and-range')
+page.div(class_='channels-and-range', style_='display: flex;flex-wrap:nowrap;justify-content:space-around;')
+page.div(style_='display: block;')
 page.a(href=plot6, target='_blank')
 page.img(class_='channels-contrib-img', src=plot6)
 page.a.close()#channels-contrib plot
+page.div.close()#close plot6 div
+page.div(class_='scroll-container', style_='display: block; padding-top: 40px;')
+page.div(style_='display: block; overflow:auto; height:400px;')
+page.a(href=plot6_legend, target='_blank')
+page.img(class_='channels-contrib-img', src=plot6_legend)
+page.a.close()#legend image
+page.div.close()#overflowed window
+page.div.close()#scroll container
 page.div.close()#channels-and-range
 
 
@@ -554,8 +752,8 @@ page.div(class_='panel-group', id_='results')
 # for each auxiliary channel create information container and put plots in it
 for i, (ch, lassocoef, plot1, plot2, plot3, ts) in enumerate(results):
     # Set container color/context based on lasso coefficient
-    if lassocoef is None:
-        h = '%s [flat]' % ch
+    if lassocoef == 0:
+         break
     elif plot1 is None:
         h = '%s [lasso coefficient = %.4f] (Below threshold)' % (ch, lassocoef)
     else:
@@ -587,25 +785,28 @@ for i, (ch, lassocoef, plot1, plot2, plot3, ts) in enumerate(results):
             page.a(href=p, target='_blank')
             page.img(class_='img-responsive', src=p)
             page.a.close()
+        if args.cluster is True:
+            if clusters[i][0] is None:
+                page.p("<font size = '3'><br />No channels were highly correlated with this channel.</font>")
+            else:
+                page.div(class_='clusters', style_='display: flex;flex-wrap:nowrap;justify-content:space-around;')
+                page.div(style_='display: block;')
+                page.a(href=clusters[i][0], target='_blank')
+                page.img(class_='img-responsive', src=clusters[i][0])
+                page.a.close()
+                page.div.close()#close plot7 div
+                page.div(class_='scroll-container', style_='display: block; padding-top: 40px;')
+                page.div(style_='display: block; overflow:auto; height: 375px;')
+                page.a(href=clusters[i][1], target='_blank')
+                page.img(class_='img-responsive', src=clusters[i][1])
+                page.a.close()#legend image
+                page.div.close()#overflowed window
+                page.div.close()#scroll container
+                page.div.close()#channels-summation
     page.div.close()  # panel-body
     page.div.close()  # panel-collapse
     page.div.close()  # panel
 page.div.close()  # panel-group
-
-# params
-def write_param(param, value):
-    page.p()
-    page.strong('%s: ' % param)
-    page.add(str(value))
-    page.p.close()
-
-page.h2('Parameters')
-page.p('This analysis used the following parameters:')
-write_param('Start time', '%s (%d)' % (from_gps(start), start))
-write_param('End time', '%s (%d)' % (from_gps(end), end))
-write_param('Range channel',
-            '%s (%s)' % (rangechannel, args.range_frametype or '-'))
-
 page.div.close()  # container
 with open('index.html', 'w') as f:
     print(str(page), file=f)

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -115,7 +115,7 @@ parser.add_argument('-R', '--range-frametype',
                     help='frametype for --range-channel')
 parser.add_argument('-O', '--remove-outliers', type=float, default=None,
                     help='Std. dev. limit for removing outliers')
-parser.add_argument('-t', '--threshold', type=float, default=0.0001, 
+parser.add_argument('-t', '--threshold', type=float, default=0.0001,
                     help='threshold for making a plot')
 
 psig = parser.add_argument_group('Signal processing options')
@@ -165,7 +165,7 @@ else:
 if args.remove_outliers:
     print('-- Removing outliers above %f sigma' % args.remove_outliers)
     remove_outliers(rangets, args.remove_outliers)
-    
+
 # create scaled versions of data to compare to each other
 print("-- Creating scaled data")
 rangescaled = rangets.detrend()
@@ -228,7 +228,7 @@ except:
             gooddata[k] = v
     auxdata = gooddata
     data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
-        
+
 # -- perform LASSO regression -------------------------------------------------
 
 # create model
@@ -342,8 +342,8 @@ def process_channel(input_,):
             else:
                 raise
         plot.close()
-           
-        
+
+
         # Create scaled, sign-corrected, and overlayed timeseries
 
         tsscaled = scale(ts.value)
@@ -402,7 +402,7 @@ def process_channel(input_,):
                 raise
 
         scatPlot.close()
-          
+
     # increment counter and print status
     with counter.get_lock():
         counter.value += 1
@@ -440,8 +440,7 @@ plt.close()
 # -- process channels
 pool = multiprocessing.Pool(nprocplot)
 results = pool.map(process_channel, enumerate(auxdata.iteritems()))
-	
-# sort results by the lasso coefficient
+# -- sort results by the lasso coefficient
 results=sorted(results, key=lambda x: abs(x[1]), reverse=True)
 
 # generate plots for channel contribution to model
@@ -588,7 +587,7 @@ def generate_clusters(input_,):
             other+=1
         if len(currentCluster) == 0:
             return plot7, plot7_legend
-        else: 
+        else:
             colors = []
             labels = []
             fig = plt.figure(figsize=(8,5))
@@ -757,7 +756,7 @@ for i, (ch, lassocoef, plot1, plot2, plot3, ts) in enumerate(results):
     else:
         context = 'panel-info'
     page.div(class_='panel %s' % context)
-    
+
     # heading
     page.div(class_='panel-heading')
     page.a(h, class_='panel-title', href='#channel%d' % i,

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -318,7 +318,7 @@ def process_channel(input_,):
         if(abs(lassocoef) < args.threshold):
             plot1 = None
             plot2 = None
-	    plot3 = None
+            plot3 = None
             return chan, lassocoef, plot1, plot2, plot3, ts
         # -- Create time series subplot
         plot = TimeSeriesPlot(rangets, ts, sep=True, sharex=True,
@@ -346,16 +346,16 @@ def process_channel(input_,):
         
         # Create scaled, sign-corrected, and overlayed timeseries
 
-	tsscaled = scale(ts.value)
-	if lassocoef < 0:
+        tsscaled = scale(ts.value)
+        if lassocoef < 0:
             tsscaled = numpy.negative(tsscaled)
-	fig = plt.figure(figsize=(12,6))
-	plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
-	plt.plot(tsscaled, label=chan.replace("_","\_"))
-	plt.xlabel('Time [min]')
-	plt.ylabel('Scaled amplitude [arbitrary units]')
-	plt.legend(loc='best')
-	plt.tight_layout()
+        fig = plt.figure(figsize=(12,6))
+        plt.plot(scale(rangets.value), label=rangechannel.replace("_","\_"))
+        plt.plot(tsscaled, label=chan.replace("_","\_"))
+        plt.xlabel('Time [min]')
+        plt.ylabel('Scaled amplitude [arbitrary units]')
+        plt.legend(loc='best')
+        plt.tight_layout()
 
         plot2 = '%s_COMPARISON-%s.png' % (channelstub, gpsstub)
         try:
@@ -388,10 +388,10 @@ def process_channel(input_,):
         scatPlot.add_line(ts, rangeFit, color="black")
         scatPlot.set_figheight(plotHeight)
         scatPlot.set_figwidth(plotWidth)
-	scatPlot.tight_layout()
+        scatPlot.tight_layout()
 
         plot3 = '%s_SCATTER-%s.png' % (channelstub, gpsstub)
-	try:
+        try:
             scatPlot.save(plot3)
         except (IOError, IndexError):
             scatPlot.save(plot3)
@@ -602,10 +602,10 @@ def generate_clusters(input_,):
                 line = plt.plot(scale(currentCluster[i][1].value)*numpy.sign(input_[1][1])*numpy.sign(currentCluster[i][2]), label=currentCluster[i][3].replace("_","\_") + ', r = ' + str('{0:.2}'.format(currentCluster[i][2])))
                 colors.append(line[0].get_color())
                 labels.append(line[0].get_label())
-	    plt.xlabel('Time [min]')
-	    plt.ylabel('Scaled amplitude [arbitrary units]')
+            plt.xlabel('Time [min]')
+            plt.ylabel('Scaled amplitude [arbitrary units]')
             plt.title('Highly Correlated Channels')
-	    plt.tight_layout()
+            plt.tight_layout()
 
             plot7 = '%s_CLUSTER-%s.png' % (re_delim.sub('_', str(currentchan)).replace('_', '-', 1), gpsstub)
             try:


### PR DESCRIPTION
Added:
-scatter plots for each channel
-individual channel contributions plot
-summation of channel contributions plot

Fixed:
-if no alpha is specified, the alpha used by LassoCV() is retrieved and used
-changed default threshold
-auxdata only includes non-flat channels before and for lasso model fitting
-number of non-zero coefficients is not just number of channels above threshold
-scaling the timeseries (for overlayed plots) using preprocessing.scale instead of timeseries.detrend()

Output: https://ldas-jobs.ligo-la.caltech.edu/~alexandra.macedo/detchar/LASSO/test/1-14-18/
Command used to generate:
```~/git/gwdetchar/bin/gwdetchar-lasso-correlation 1171432800 1171453380 -f ~/public_html/detchar/chans.txt -a .1 -t .01 -O 2 -o ~/public_html/detchar/LASSO/test/1-14-18 -i L1```